### PR TITLE
do not show box-shadow above menu on non-mobile pages

### DIFF
--- a/app/assets/stylesheets/_settings.scss
+++ b/app/assets/stylesheets/_settings.scss
@@ -406,7 +406,7 @@ $offcanvas-transition-timing: ease;
 $offcanvas-fixed-reveal: true;
 $offcanvas-exit-background: rgba($white, 0.25);
 $maincontent-class: 'off-canvas-content';
-$maincontent-shadow: 0 0 10px rgba($black, 0.5);
+$maincontent-shadow: none;
 
 // 25. Orbit
 // ---------


### PR DESCRIPTION
### Before:

<img width="1271" alt="screen shot 2016-09-16 at 10 37 36 pm" src="https://cloud.githubusercontent.com/assets/888422/18606371/1c8a9d4e-7c63-11e6-87b5-097dc2f3f549.png">
### After:

<img width="1270" alt="screen shot 2016-09-16 at 11 09 11 pm" src="https://cloud.githubusercontent.com/assets/888422/18606374/270b96b0-7c63-11e6-865c-a23b7531f445.png">
