### PR TITLE
Make tooltips on business logos show links to business websites

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,8 @@ gem 'coffee-rails', '~> 4.1.0'
 # See https://github.com/rails/execjs#readme for more supported runtimes
 # gem 'therubyracer', platforms: :ruby
 # Use Foundation for building the UI
-gem 'foundation-rails'
+# TODO: switch to 6.3 once it's released - it will allow for HTML in tooltips
+gem 'foundation-rails', github: 'mbyczkowski/foundation-rails'
 # Use HAML for building HTML templates
 gem 'haml'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -15,6 +15,15 @@ GIT
       sass-rails (~> 5.0)
       selectize-rails (~> 0.6)
 
+GIT
+  remote: git://github.com/mbyczkowski/foundation-rails.git
+  revision: 40d745e38b297fd13c4b25eefd5ebceb78819190
+  specs:
+    foundation-rails (6.2.4.0)
+      railties (>= 3.1.0)
+      sass (>= 3.3.0, < 3.5)
+      sprockets-es6 (>= 0.9.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -87,10 +96,6 @@ GEM
       activemodel
     erubis (2.7.0)
     execjs (2.7.0)
-    foundation-rails (6.2.4.0)
-      railties (>= 3.1.0)
-      sass (>= 3.3.0, < 3.5)
-      sprockets-es6 (>= 0.9.0)
     friendly_id (5.1.0)
       activerecord (>= 4.0.0)
     globalid (0.3.6)
@@ -204,7 +209,7 @@ DEPENDENCIES
   byebug
   clearance
   coffee-rails (~> 4.1.0)
-  foundation-rails
+  foundation-rails!
   friendly_id (~> 5.1.0)
   haml
   jbuilder (~> 2.0)

--- a/app/dashboards/business_dashboard.rb
+++ b/app/dashboards/business_dashboard.rb
@@ -13,6 +13,7 @@ class BusinessDashboard < Administrate::BaseDashboard
     created_at: Field::DateTime,
     updated_at: Field::DateTime,
     name: Field::String,
+    website_url: Field::String,
     offers_catering: Field::Boolean,
   }.freeze
 
@@ -37,6 +38,7 @@ class BusinessDashboard < Administrate::BaseDashboard
     :updated_at,
     :name,
     :slug,
+    :website_url,
     :offers_catering,
   ].freeze
 
@@ -46,12 +48,13 @@ class BusinessDashboard < Administrate::BaseDashboard
   FORM_ATTRIBUTES = [
     :name,
     :offers_catering,
+    :website_url,
   ].freeze
 
   # Overwrite this method to customize how users are displayed
   # across all pages of the admin dashboard.
   #
-  # def display_resource(user)
-  #   "User ##{user.id}"
-  # end
+  def display_resource(business)
+    business.name
+  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -80,4 +80,12 @@ module ApplicationHelper
   def businesses_with_catering
     @businesses_with_catering ||= Business.with_logo.with_catering
   end
+
+  def business_link(business)
+    if business.website_url
+      link_to business.name, business.website_url
+    else
+      business.name
+    end
+  end
 end

--- a/app/views/partials/_businesses.html.haml
+++ b/app/views/partials/_businesses.html.haml
@@ -2,4 +2,4 @@
   - businesses.each_with_index do |b, i|
     - klass = i == businesses.length - 1 ? 'end' : ''
     .float-left{class: klass}
-      = image_tag "businesses/#{b.logo_url}", "data-tooltip aria-haspopup" => "true","class" => "has-tip","data-disable-hover" => "false","tabindex" => "1","title" => "#{b.name}"
+      = image_tag "businesses/#{b.logo_url}", "data-allow-html" => true, "data-tooltip aria-haspopup" => "true","class" => "has-tip","data-disable-hover" => "false","tabindex" => "1","title" => "#{business_link(b)}"

--- a/db/migrate/20161106213711_add_to_website_url_to_businesses.rb
+++ b/db/migrate/20161106213711_add_to_website_url_to_businesses.rb
@@ -1,0 +1,5 @@
+class AddToWebsiteUrlToBusinesses < ActiveRecord::Migration
+  def change
+    add_column :businesses, :website_url, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161027050836) do
+ActiveRecord::Schema.define(version: 20161106213711) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -24,6 +24,7 @@ ActiveRecord::Schema.define(version: 20161027050836) do
     t.string   "slug",                            null: false
     t.string   "website"
     t.string   "logo_url"
+    t.string   "website_url"
   end
 
   add_index "businesses", ["logo_url"], name: "index_businesses_on_logo_url", using: :btree


### PR DESCRIPTION
- unfortunately, Foundation 6.2 doesn't allow for HTML elements as part
  of Tooltip (it's going to be available as an option in 6.3), so we
  need to use github repo instead of a gem for now
- also, added ability for admins to edit website url for each business
  and display it automatically as part of tooltip changes