### PR TITLE
make inline SVGs work in heroku

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,6 +37,9 @@ gem 'clearance'
 # Generate friendly IDs
 gem 'friendly_id', '~> 5.1.0'
 
+# Embed SVGs inline from files
+gem 'inline_svg'
+
 # Use ActiveModel has_secure_password
 # gem 'bcrypt', '~> 3.1.7'
 
@@ -57,4 +60,8 @@ group :development do
 
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'
+end
+
+group :production do
+  gem 'rails_12factor'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -103,6 +103,10 @@ GEM
     haml (4.0.7)
       tilt
     i18n (0.7.0)
+    inline_svg (0.11.0)
+      activesupport (>= 4.0)
+      loofah (>= 2.0)
+      nokogiri (~> 1.6)
     jbuilder (2.4.1)
       activesupport (>= 3.0.0, < 5.1)
       multi_json (~> 1.2)
@@ -133,7 +137,7 @@ GEM
       mini_portile2 (~> 2.1.0)
     normalize-rails (3.0.3)
     pg (0.18.4)
-    rack (1.6.4)
+    rack (1.6.5)
     rack-test (0.6.3)
       rack (>= 1.0)
     rails (4.2.6)
@@ -155,6 +159,11 @@ GEM
       rails-deprecated_sanitizer (>= 1.0.1)
     rails-html-sanitizer (1.0.3)
       loofah (~> 2.0)
+    rails_12factor (0.0.3)
+      rails_serve_static_assets
+      rails_stdout_logging
+    rails_serve_static_assets (0.0.5)
+    rails_stdout_logging (0.0.5)
     railties (4.2.6)
       actionpack (= 4.2.6)
       activesupport (= 4.2.6)
@@ -164,8 +173,8 @@ GEM
     rdoc (4.2.2)
       json (~> 1.4)
     sass (3.4.22)
-    sass-rails (5.0.4)
-      railties (>= 4.0.0, < 5.0)
+    sass-rails (5.0.6)
+      railties (>= 4.0.0, < 6)
       sass (~> 3.1)
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
@@ -182,13 +191,13 @@ GEM
       babel-source (>= 5.8.11)
       babel-transpiler
       sprockets (>= 3.0.0)
-    sprockets-rails (3.0.4)
+    sprockets-rails (3.2.0)
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
     thor (0.19.1)
     thread_safe (0.3.5)
-    tilt (2.0.4)
+    tilt (2.0.5)
     turbolinks (2.5.3)
       coffee-rails
     tzinfo (1.2.2)
@@ -212,10 +221,12 @@ DEPENDENCIES
   foundation-rails!
   friendly_id (~> 5.1.0)
   haml
+  inline_svg
   jbuilder (~> 2.0)
   jquery-rails
   pg
   rails (= 4.2.6)
+  rails_12factor
   sass-rails (~> 5.0)
   sdoc (~> 0.4.0)
   spring

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -232,17 +232,6 @@ module ApplicationHelper
     ]
   end
 
-  def embedded_svg(filename, options = {})
-    assets = Rails.application.assets
-    file = assets.find_asset(filename).source.force_encoding("UTF-8")
-    doc = Nokogiri::HTML::DocumentFragment.parse file
-    svg = doc.at_css "svg"
-    if options[:class].present?
-      svg["class"] = options[:class]
-    end
-    raw doc
-  end
-
   def featured_businesses
     @features_businesses ||= Business.with_logo
   end

--- a/app/views/layouts/_footer.html.haml
+++ b/app/views/layouts/_footer.html.haml
@@ -9,9 +9,6 @@
       .button Sign Up
 
     .social-media-icons
-      - social_media_links.each do |site|
-        .social-media-icon
-          = link_to (embedded_svg "icons/" + site[:icon]), site[:link], { target: "_blank" }
-
+      = render partial: 'layouts/social_media'
 
   .made-by MADE BY VOLUNTEERS 2016

--- a/app/views/layouts/_header.html.haml
+++ b/app/views/layouts/_header.html.haml
@@ -17,9 +17,7 @@
             = image_tag 'logo.png'
 
         .social-media-icons
-          - social_media_links.each do |site|
-            .social-media-icon
-              = link_to (embedded_svg "icons/" + site[:icon]), site[:link], { target: "_blank" }
+          = render partial: 'layouts/social_media'
           = link_to 'Donate', '/donate', class: 'button'
 
         %ul.dropdown.menu{'data-dropdown-menu': true}
@@ -32,4 +30,3 @@
                   - menu_item[:submenu].each do |submenu_item|
                     %li
                       = link_to submenu_item[:name], submenu_item[:url]
-

--- a/app/views/layouts/_social_media.html.haml
+++ b/app/views/layouts/_social_media.html.haml
@@ -1,0 +1,4 @@
+- social_media_links.each do |site|
+  .social-media-icon
+    = link_to site[:link], target: "_blank" do
+      = inline_svg "icons/" + site[:icon]


### PR DESCRIPTION
- when using precompiled assets `Rails.application.assets` is not set,
  and instead static assets should be fetched from `/public/assets`. The
  `inline_svg` gem makes SVGs work both in development and production
  modes